### PR TITLE
feat(env): add central env config and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=<project_url> 
+NEXT_SUPABASE_PUBLISHABLE_KEY=<publishable_key>

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,12 @@
+/**
+ * Centralizes access to environment variables
+ */
+export const config: Config = {
+    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    NEXT_SUPABASE_PUBLISHABLE_KEY: process.env.NEXT_SUPABASE_PUBLISHABLE_KEY!,
+}
+
+export interface Config {
+    NEXT_PUBLIC_SUPABASE_URL: string;
+    NEXT_SUPABASE_PUBLISHABLE_KEY: string;
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,3 +1,4 @@
+import { config } from '@/config/env'
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
@@ -5,8 +6,8 @@ export async function createClient() {
   const cookieStore = await cookies()
 
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_SUPABASE_PUBLISHABLE_KEY!,
+    config.NEXT_PUBLIC_SUPABASE_URL,
+    config.NEXT_SUPABASE_PUBLISHABLE_KEY,
     {
       cookies: {
         getAll() {


### PR DESCRIPTION
## Objective
- Adds a `.env.example` file to help other contributors easily setup the project with appropriate environment variables.
- Exports a central `config` object from `src/config/env` file for easy access of env variabels.

## Note
- In next js development in local, it is a common practice to use `.env.local` for developer specific env variables. while `.env` file is more preferred for production mode.

Please check all other necessary environment variables are included in `.env.example` and `src/config/env`