### PR TITLE
Fix: Archive date saved as previous day

### DIFF
--- a/src/components/AddArchiveSheet.tsx
+++ b/src/components/AddArchiveSheet.tsx
@@ -55,25 +55,33 @@ export function AddArchiveSheet() {
   }
 
   const queryClient = useQueryClient();
+  
 
-  const mutation = useMutation({
-    mutationFn: async () => {
-      await addArchive({
-        title,
-        slug,
-        content,
-        date: date!.toISOString(), // store as ISO string
-      });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["articles"] });
-      setOpen(false);
-      setTitle("");
-      setSlug("");
-      setContent("");
-      setDate(undefined);
-    },
-  });
+const mutation = useMutation({
+  mutationFn: async () => {
+    if (!date) return;
+
+    const localISODate = new Date(
+      date.getTime() - date.getTimezoneOffset() * 60000
+    ).toISOString();
+
+    await addArchive({
+      title,
+      slug,
+      content,
+      date: localISODate,
+    });
+  },
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ["articles"] });
+    setOpen(false);
+    setTitle("");
+    setSlug("");
+    setContent("");
+    setDate(undefined);
+  },
+});
+
 
   async function handleSubmit() {
     if (!title || !slug || !content || !date) return;


### PR DESCRIPTION
When adding an archive, the selected date was saved as a day earlier.
This happened because toISOString() converted the local date to UTC.

**Fix**:  Adjusted the date with the timezone offset before saving:

```
const localISODate = new Date(
  date.getTime() - date.getTimezoneOffset() * 60000
).toISOString();`

```


Now the archive saves with the correct date.