### PR TITLE
feat: add author to articles table

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -6,9 +6,6 @@ import { AddArchiveSheet } from "./AddArchiveSheet";
 const Navbar = async () => {
 
   const user = await getUser()
-  if(user){
-    console.log(user)
-  }
 
   return (
     <section className="flex mx-auto w-full pt-10">
@@ -36,7 +33,7 @@ const Navbar = async () => {
           </Link>{" "}
           to view the source code.
         </p>
-        {user && <AddArchiveSheet />}
+        {user && <AddArchiveSheet user={user} />}
       </div>
     </section>
   );

--- a/supabase/migrations/20250915023023_remote_schema.sql
+++ b/supabase/migrations/20250915023023_remote_schema.sql
@@ -1,0 +1,47 @@
+drop extension if exists "pg_net";
+
+revoke delete on table "public"."articles" from "anon";
+
+revoke insert on table "public"."articles" from "anon";
+
+revoke references on table "public"."articles" from "anon";
+
+revoke select on table "public"."articles" from "anon";
+
+revoke trigger on table "public"."articles" from "anon";
+
+revoke truncate on table "public"."articles" from "anon";
+
+revoke update on table "public"."articles" from "anon";
+
+revoke delete on table "public"."articles" from "authenticated";
+
+revoke insert on table "public"."articles" from "authenticated";
+
+revoke references on table "public"."articles" from "authenticated";
+
+revoke select on table "public"."articles" from "authenticated";
+
+revoke trigger on table "public"."articles" from "authenticated";
+
+revoke truncate on table "public"."articles" from "authenticated";
+
+revoke update on table "public"."articles" from "authenticated";
+
+revoke delete on table "public"."articles" from "service_role";
+
+revoke insert on table "public"."articles" from "service_role";
+
+revoke references on table "public"."articles" from "service_role";
+
+revoke select on table "public"."articles" from "service_role";
+
+revoke trigger on table "public"."articles" from "service_role";
+
+revoke truncate on table "public"."articles" from "service_role";
+
+revoke update on table "public"."articles" from "service_role";
+
+alter table "public"."articles" add column "author" uuid default auth.uid();
+
+


### PR DESCRIPTION
## Objective
This PR adds author field to the article table which is a reference to the auth table provided by supabase by default.

## Changes
- Adds `author` field to `articles` table which is a reference to `auth`
- Displays author's email in a read-only input field of the form that adds archive.

## Note
**Please make sure the migrations are successfully run for the database**. Steps to run migrations:

1. Login to supabase with CLI (if not already done): `pnpm supabase login`
2. Link the project (if not already done): `pnpm supabase link --project-ref <PROJECT_ID>`
3. Run migration: `pnpm supabase db push`